### PR TITLE
Refactor/split functionality

### DIFF
--- a/iris_app/app.py
+++ b/iris_app/app.py
@@ -1,63 +1,29 @@
-from flask import Flask, render_template, request
-import numpy as np
-import joblib
+from typing import Optional, Dict, List
+from flask import Flask, Request, Response, render_template
 
-#create instance of Flask
+from services.errors import get_request_errors
+from services.prediction_service import get_prediction
+
 app = Flask(__name__)
 
-@app.route('/')
-def home():
-    return render_template('home.html')
+
+@app.route("/")
+def render_home_page(request: Request):
+    return render_template("home.html")
 
 
-@app.route('/predict/', methods=['GET','POST'])
-def predict():
+@app.route("/predict/", methods=["GET","POST"])
+def predict(request: Request):
     
-    if request.method == "POST":
-        
-        #get form data
-        sepal_length = request.form.get('sepal_length')
-        sepal_width = request.form.get('sepal_width')
-        petal_length = request.form.get('petal_length')
-        petal_width = request.form.get('petal_width')
-        
-        
-        #call preprocessDataAndPredict and pass inputs
-        try:
-            prediction = preprocessDataAndPredict(sepal_length,       sepal_width, petal_length, petal_width)            #pass prediction to template
-            return render_template('predict.html', prediction = prediction)
-   
-        except ValueError:
-            return "Please Enter valid values"
-  
-        pass
-    pass
+    request_error: Optional[str] = get_request_errors(request)
+    
+    if not request_error:
+        petal_measures: Dict[str, float] = request.get("form")
+        prediction: str = get_prediction(petal_measures)
+        return render_template("predict.html", prediction = prediction)
 
-def preprocessDataAndPredict(sepal_length, sepal_width, petal_length, petal_width):
-    
-    #keep all inputs in array
-    test_data = [sepal_length, sepal_width, petal_length, petal_width]
-    print(test_data)
-    
-    #convert value data into numpy array
-    test_data = np.array(test_data)
-    
-    #reshape array
-    test_data = test_data.reshape(1,-1)
-    print(test_data)
-    
-    #open file
-    file = open("output/randomforest_model.pkl","rb")
-    
-    #load trained model
-    trained_model = joblib.load(file)
-    
-    #predict
-    prediction = trained_model.predict(test_data)
-    
-    return prediction
-    
-    pass
+    return request_error
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     app.run(debug=True)

--- a/iris_app/services/error_service.py
+++ b/iris_app/services/error_service.py
@@ -1,0 +1,25 @@
+from flask import Request
+from typing import Dict, Optional
+
+
+def is_all_float_type(form_data: Dict[str, float]) -> bool:
+    """Check if all petal measure values are of type float"""
+    return all([
+        isinstance(petal_measure, float)
+        for _, petal_measure in form_data.items()
+    ])
+
+
+def get_request_errors(request: Request) -> Optional[str]:
+    """"Handle request semantics for prediction request"""
+    if not request.get("method") == "POST":
+        return "Invalid request method used"
+        
+    request_form: Optional[Dict] = request.get("form")
+    if not request_form:
+        return "Please enter values in the form"
+
+    if not is_all_float_type(request_form):
+        return "Please enter valid petal measure values"
+
+    return None

--- a/iris_app/services/prediction_service.py
+++ b/iris_app/services/prediction_service.py
@@ -1,0 +1,40 @@
+import joblib
+
+from numpy import ndarray, array
+from typing import Dict, List
+
+MODEL_PATH: str = "output/randomforest_model.pkl"
+
+
+def preprocess_data(petal_measures: Dict[str, float]) -> ndarray:        
+    """Extract petal measures as a numpy array (column per feature value)"""
+    prediction_data: List[float] = [
+        petal_measures.get("sepal_length"), 
+        petal_measures.get("sepal_width"), 
+        petal_measures.get("petal_length"), 
+        petal_measures.get("petal_width")
+    ]
+    
+    prediction_data = array(prediction_data).reshape(1,-1)
+    
+    return prediction_data
+
+
+def get_local_model(model_path: str):
+    """Get locally stored model"""
+    with open(model_path,"rb") as path:
+        trained_model = joblib.load(path)
+
+    return trained_model
+
+
+def get_prediction(petal_measures: Dict[str, float]) -> str:
+    """Get a prediction for a set of petal measures using a locally stored model"""
+    prediction_data: ndarray = preprocess_data(petal_measures)
+
+    trained_model = get_local_model(MODEL_PATH)
+
+    prediction = trained_model.predict(prediction_data)
+    
+    return prediction
+    


### PR DESCRIPTION
general
- added type annotations, this is not necessary, but provides extra information on data flowing in and out of functions. In combination with a good function name, it provides very good documentation on its own. 

mnelson.txt
- removed

main.py
- removed

app.py
- renamed home template serving function
- error checks moved to error_service.py
- preprocessing and prediction code moved to prediction_service.py
- error checks and prediction code now imported from the respective services

services/error_service.py
- explicit error checks moved to separate function
- removed ValueError exception handling in predict route for explicit checks

services/prediction_service.py
- preprocessing code split off from preprocessDataAndPredict into separate function
- prediction code split off from preprocessDataAndPredict into separate function
- removed preprocessDataAndPredict function
- model loading separated out in own function
- now using context manager to load model so file is automatically closed
